### PR TITLE
Show absolute representation of less significant digits

### DIFF
--- a/trunk/source/Tools.cpp
+++ b/trunk/source/Tools.cpp
@@ -89,9 +89,9 @@ wstring ToMoneyStr(int iCash)
 	wchar_t wszBuf[32];
 	
 	if(iMillions)
-		swprintf(wszBuf, L"%d.%.3d.%.3d", iMillions, iThousands, iRest);
+		swprintf(wszBuf, L"%d.%.3d.%.3d", iMillions, abs(iThousands), abs(iRest));
 	else if(iThousands)
-		swprintf(wszBuf, L"%d.%.3d", iThousands, iRest);
+		swprintf(wszBuf, L"%d.%.3d", iThousands, abs(iRest));
 	else
 		swprintf(wszBuf, L"%d", iRest);
 


### PR DESCRIPTION
Will properly format negative numbers (i.e. -10.600$ instead of -10.-600$), see http://discoverygc.com/forums/showthread.php?tid=134618