### PR TITLE
Change AUTOBUY_CARTITEM iCount to signed int

### DIFF
--- a/trunk/plugins/autobuy/Main.cpp
+++ b/trunk/plugins/autobuy/Main.cpp
@@ -244,7 +244,7 @@ void LoadSettings()
 struct AUTOBUY_CARTITEM
 {
 	uint iArchID;
-	uint iCount;
+	int iCount;
 	wstring wscDescription;
 };
 
@@ -685,7 +685,7 @@ void PlayerAutobuy(uint iClientID, uint iBaseID)
 
 			if ((*it4).iCount != 0)
 			{
-				PrintUserCmdText(iClientID, L"Auto-Buy(%s): Bought %u unit(s), cost: %s$", (*it4).wscDescription.c_str(), (*it4).iCount, ToMoneyStr(iCost).c_str());
+				PrintUserCmdText(iClientID, L"Auto-Buy(%s): Bought %d unit(s), cost: %s$", (*it4).wscDescription.c_str(), (*it4).iCount, ToMoneyStr(iCost).c_str());
 			}
 		}
 	}


### PR DESCRIPTION
Handle negative iCount values properly (i.e. due to bot capacity nerf), see: http://discoverygc.com/forums/showthread.php?tid=134618 (it should have displayed -53 instead of 4294967243). This change will make AUTOBUY_CARTITEM->iCount consistent with CARGO_INFO->iCount.

NOTE: I don't have access to a test environment at the moment (I'm away for the holidays) so I haven't been able to test this change yet. It looks to me like it should be good, but if you have any doubts at all then don't merge it yet.