### PR TITLE
playercntl: Don't pretend reloadlockedships command is unknown after executing it

### DIFF
--- a/trunk/plugins/playercntl_plugin/Main.cpp
+++ b/trunk/plugins/playercntl_plugin/Main.cpp
@@ -1465,6 +1465,7 @@ bool ExecuteCommandString_Callback(CCmds* cmds, const wstring &wscCmd)
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
 		Rename::ReloadLockedShips();
+		return true;
 	}
     return false;
 }


### PR DESCRIPTION
Return true.