### PR TITLE
Dice extension

### DIFF
--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -903,7 +903,7 @@ USERCMD UserCmds[] =
 	{ L"/pos",			MiscCmds::UserCmd_Pos,			L"Usage: /pos" },
 	{ L"/stuck",		MiscCmds::UserCmd_Stuck,		L"Usage: /stuck" },
 	{ L"/droprep",		MiscCmds::UserCmd_DropRep,		L"Usage: /droprep" },
-	{ L"/dice",			MiscCmds::UserCmd_Dice,			L"Usage: /dice [max]" },
+	{ L"/roll",			MiscCmds::UserCmd_Dice,			L"Usage: /roll 1d20 | 1d20+3 | etc." },
 	{ L"/coin",			MiscCmds::UserCmd_Coin,			L"Usage: /coin" },
 	{ L"/pimpship",		PimpShip::UserCmd_PimpShip,		L"Usage: /pimpship" },
 	{ L"/showsetup",	PimpShip::UserCmd_ShowSetup,	L"Usage: /showsetup" },
@@ -1106,7 +1106,7 @@ void UserCmd_Help(uint iClientID, const wstring &wscParam)
 	PrintUserCmdText(iClientID, L"/pos");
 	PrintUserCmdText(iClientID, L"/stuck");
 	PrintUserCmdText(iClientID, L"/droprep");
-	PrintUserCmdText(iClientID, L"/dice [max]");
+	PrintUserCmdText(iClientID, L"/roll 1d20");
 	PrintUserCmdText(iClientID, L"/coin");
 
 	if (!set_bEnableRenameMe)

--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -903,6 +903,7 @@ USERCMD UserCmds[] =
 	{ L"/pos",			MiscCmds::UserCmd_Pos,			L"Usage: /pos" },
 	{ L"/stuck",		MiscCmds::UserCmd_Stuck,		L"Usage: /stuck" },
 	{ L"/droprep",		MiscCmds::UserCmd_DropRep,		L"Usage: /droprep" },
+	{ L"/dice",			MiscCmds::UserCmd_Dice,			L"Usage: /dice 1d20 | 1d20+3 | etc."},
 	{ L"/roll",			MiscCmds::UserCmd_Dice,			L"Usage: /roll 1d20 | 1d20+3 | etc." },
 	{ L"/coin",			MiscCmds::UserCmd_Coin,			L"Usage: /coin" },
 	{ L"/pimpship",		PimpShip::UserCmd_PimpShip,		L"Usage: /pimpship" },

--- a/Plugins/Public/playercntl_plugin/MiscCmds.cpp
+++ b/Plugins/Public/playercntl_plugin/MiscCmds.cpp
@@ -304,7 +304,7 @@ namespace MiscCmds
 			// Only print the steps taken if less than 10 dice was rolled.
 			if (rollCount < 10)
 			{
-				PrintUserCmdText(iFromClientID, stows(diceResultSteps));
+				PrintLocalUserCmdText(iFromClientID, stows(diceResultSteps), set_iLocalChatRange);
 			}
 
 		}

--- a/Plugins/Public/playercntl_plugin/MiscCmds.cpp
+++ b/Plugins/Public/playercntl_plugin/MiscCmds.cpp
@@ -314,9 +314,9 @@ namespace MiscCmds
 		else
 		{
 			PrintUserCmdText(iFromClientID, L"Usage: (NumDice) d (DiceSides) [+-] (Modifier)");
-			PrintUserCmdText(iFromClientID, L"Examples:	/roll 1d20 -- Roll 1, 20 sided die");
-			PrintUserCmdText(iFromClientID, L"		       /roll 1d8+4 -- Roll 1, 8 sided die and add 8");
-			PrintUserCmdText(iFromClientID, L"           /roll 4d20+2 -- Roll 4, 20 sided dice, adding 2 to each die rolled");
+			PrintUserCmdText(iFromClientID, L"Examples: /roll 1d20 -- Roll 1, 20 sided die");
+			PrintUserCmdText(iFromClientID, L"          /roll 1d8+4 -- Roll 1, 8 sided die and add 8");
+			PrintUserCmdText(iFromClientID, L"          /roll 4d20+2 -- Roll 4, 20 sided dice, adding 2 to each die rolled");
 		}
 		return true;
 	}

--- a/Plugins/Public/playercntl_plugin/MiscCmds.cpp
+++ b/Plugins/Public/playercntl_plugin/MiscCmds.cpp
@@ -230,8 +230,7 @@ namespace MiscCmds
 	Roll dice for everyone within 6km of a vessel. Supports 1d20 formatting.
 	*/
 	bool MiscCmds::UserCmd_Dice(uint iFromClientID, const wstring &wscCmd, const wstring &wscParam, const wchar_t *usage)
-	{
-
+	{
 		boost::wregex expr(L"(\\d{1,2})[Dd](\\d{1,3})(([+\\-*])?(\\d{1,5}))?");
 		boost::wsmatch sm;
 
@@ -265,7 +264,7 @@ namespace MiscCmds
 			}
 
 			string diceResultSteps = "";
-			int number = 0;
+			uint number = 0;
 
 			for (int i = 0; i < rollCount; i++)
 			{
@@ -317,10 +316,8 @@ namespace MiscCmds
 			PrintUserCmdText(iFromClientID, L"Usage: /roll 1d20");
 			PrintUserCmdText(iFromClientID, L"       /roll 1d8+4");
 			PrintUserCmdText(iFromClientID, L"       /roll 4d20+2");
-		}
-
-		return true;
-
+		}
+		return true;
 	}
 
 	/** Throw the dice and tell all players within 6 km */

--- a/Plugins/Public/playercntl_plugin/MiscCmds.cpp
+++ b/Plugins/Public/playercntl_plugin/MiscCmds.cpp
@@ -248,7 +248,6 @@ namespace MiscCmds
 
 	bool MiscCmds::UserCmd_Dice(uint iFromClientID, const wstring &wscCmd, const wstring &wscParam, const wchar_t *usage)
 	{
-		wstring wscCharname = (const wchar_t*)Players.GetActiveCharacterName(iFromClientID);
 		boost::wregex expr(L"(\\d{1,2})[Dd](\\d{1,3})(([+\\-*])?(\\d{1,5}))?");
 		boost::wsmatch sm;
 
@@ -293,8 +292,8 @@ namespace MiscCmds
 				else if (operation == diceOperation::SUBTRACT)
 				{
 					numBuffer = _wtoi(sm[5].str().c_str());
-					number -= (randValue - numBuffer);
-					diceResultSteps.append(" - ").append(itos(numBuffer).append(")"));
+					number += (randValue - numBuffer);
+					diceResultSteps.append("(").append(itos(randValue)).append(" - ").append(itos(numBuffer).append(")"));
 				}
 				else
 				{
@@ -309,6 +308,8 @@ namespace MiscCmds
 				}
 			}
 
+			wstring wscCharname = (const wchar_t*)Players.GetActiveCharacterName(iFromClientID);
+
 			// Print the results
 			wstring diceAlert = L"%player rolled %value with the formula %formula";
 			diceAlert = ReplaceStr(diceAlert, L"%player", wscCharname);
@@ -316,8 +317,12 @@ namespace MiscCmds
 			diceAlert = ReplaceStr(diceAlert, L"%formula", sm[0].str().c_str());
 
 			PrintLocalUserCmdText(iFromClientID, diceAlert, set_iLocalChatRange);
-			PrintUserCmdText(iFromClientID, stows(diceResultSteps));
 
+			// Only print the steps taken if less than 10 dice was rolled.
+			if (rollCount < 10)
+			{
+				PrintUserCmdText(iFromClientID, stows(diceResultSteps));
+			}
 
 		}
 		else
@@ -325,7 +330,6 @@ namespace MiscCmds
 			PrintUserCmdText(iFromClientID, L"Usage: /roll 1d20");
 			PrintUserCmdText(iFromClientID, L"       /roll 1d8+4");
 			PrintUserCmdText(iFromClientID, L"       /roll 4d20+2");
-			return true;
 		}
 		return true;
 	}

--- a/Plugins/Public/playercntl_plugin/MiscCmds.cpp
+++ b/Plugins/Public/playercntl_plugin/MiscCmds.cpp
@@ -313,9 +313,10 @@ namespace MiscCmds
 		}
 		else
 		{
-			PrintUserCmdText(iFromClientID, L"Usage: /roll 1d20");
-			PrintUserCmdText(iFromClientID, L"       /roll 1d8+4");
-			PrintUserCmdText(iFromClientID, L"       /roll 4d20+2");
+			PrintUserCmdText(iFromClientID, L"Usage: (NumDice) d (DiceSides) [+-] (Modifier)");
+			PrintUserCmdText(iFromClientID, L"Examples:	/roll 1d20 -- Roll 1, 20 sided die");
+			PrintUserCmdText(iFromClientID, L"		       /roll 1d8+4 -- Roll 1, 8 sided die and add 8");
+			PrintUserCmdText(iFromClientID, L"           /roll 4d20+2 -- Roll 4, 20 sided dice, adding 2 to each die rolled");
 		}
 		return true;
 	}

--- a/Plugins/Public/playercntl_plugin/MiscCmds.cpp
+++ b/Plugins/Public/playercntl_plugin/MiscCmds.cpp
@@ -226,26 +226,9 @@ namespace MiscCmds
 		return true;
 	}
 
-	/** Throw the dice and tell all players within 6 km */
 	/*
-	bool MiscCmds::UserCmd_Dice(uint iFromClientID, const wstring &wscCmd, const wstring &wscParam, const wchar_t *usage)
-	{
-		wstring wscCharname = (const wchar_t*) Players.GetActiveCharacterName(iFromClientID);
-
-		int max = ToInt(GetParam(wscParam, ' ', 0));
-		if (max<=1)
-			max = 6;
-
-		uint number = (rand()%max)+1;
-		wstring wscMsg = set_wscDiceMsg;
-		wscMsg = ReplaceStr(wscMsg, L"%player", wscCharname);
-		wscMsg = ReplaceStr(wscMsg, L"%number", stows(itos(number)));
-		wscMsg = ReplaceStr(wscMsg, L"%max", stows(itos(max)));
-		PrintLocalUserCmdText(iFromClientID, wscMsg, set_iLocalChatRange);
-		return true;
-	}
+	Roll dice for everyone within 6km of a vessel. Supports 1d20 formatting.
 	*/
-
 	bool MiscCmds::UserCmd_Dice(uint iFromClientID, const wstring &wscCmd, const wstring &wscParam, const wchar_t *usage)
 	{
 		boost::wregex expr(L"(\\d{1,2})[Dd](\\d{1,3})(([+\\-*])?(\\d{1,5}))?");

--- a/Plugins/Public/playercntl_plugin/MiscCmds.cpp
+++ b/Plugins/Public/playercntl_plugin/MiscCmds.cpp
@@ -230,7 +230,8 @@ namespace MiscCmds
 	Roll dice for everyone within 6km of a vessel. Supports 1d20 formatting.
 	*/
 	bool MiscCmds::UserCmd_Dice(uint iFromClientID, const wstring &wscCmd, const wstring &wscParam, const wchar_t *usage)
-	{
+	{
+
 		boost::wregex expr(L"(\\d{1,2})[Dd](\\d{1,3})(([+\\-*])?(\\d{1,5}))?");
 		boost::wsmatch sm;
 
@@ -264,7 +265,7 @@ namespace MiscCmds
 			}
 
 			string diceResultSteps = "";
-			uint number = 0;
+			int number = 0;
 
 			for (int i = 0; i < rollCount; i++)
 			{
@@ -316,8 +317,10 @@ namespace MiscCmds
 			PrintUserCmdText(iFromClientID, L"Usage: /roll 1d20");
 			PrintUserCmdText(iFromClientID, L"       /roll 1d8+4");
 			PrintUserCmdText(iFromClientID, L"       /roll 4d20+2");
-		}
-		return true;
+		}
+
+		return true;
+
 	}
 
 	/** Throw the dice and tell all players within 6 km */

--- a/Plugins/Public/playercntl_plugin/MiscCmds.cpp
+++ b/Plugins/Public/playercntl_plugin/MiscCmds.cpp
@@ -244,14 +244,19 @@ namespace MiscCmds
 			// Smatch index [2] represents the dice count
 			int diceCount = _wtoi(sm[2].str().c_str());
 
+			// Smatch index [3] represents any modifier numeric value. This is set ONLY if we are using a mod-operation
+			int modifierValue;
+
 			diceOperation operation;
 			if (sm[3].str().find(L"+") == 0)
 			{
 				operation = diceOperation::ADD;
+				modifierValue = _wtoi(sm[5].str().c_str());
 			}
 			else if (sm[3].str().find(L"-") == 0)
 			{
 				operation = diceOperation::SUBTRACT;
+				modifierValue = _wtoi(sm[5].str().c_str());
 			}
 			else
 			{
@@ -260,7 +265,7 @@ namespace MiscCmds
 
 			string diceResultSteps = "";
 			uint number = 0;
-			int numBuffer;
+
 			for (int i = 0; i < rollCount; i++)
 			{
 				int randValue = (rand() % diceCount) + 1;
@@ -268,15 +273,13 @@ namespace MiscCmds
 				// If we have a modifier, apply it
 				if (operation == diceOperation::ADD)
 				{
-					numBuffer = _wtoi(sm[5].str().c_str());
-					number += (randValue + numBuffer);
-					diceResultSteps.append("(").append(itos(randValue)).append(" + ").append(itos(numBuffer).append(")"));
+					number += (randValue + modifierValue);
+					diceResultSteps.append("(").append(itos(randValue)).append(" + ").append(itos(modifierValue).append(")"));
 				}
 				else if (operation == diceOperation::SUBTRACT)
 				{
-					numBuffer = _wtoi(sm[5].str().c_str());
-					number += (randValue - numBuffer);
-					diceResultSteps.append("(").append(itos(randValue)).append(" - ").append(itos(numBuffer).append(")"));
+					number += (randValue - modifierValue);
+					diceResultSteps.append("(").append(itos(randValue)).append(" - ").append(itos(modifierValue).append(")"));
 				}
 				else
 				{


### PR DESCRIPTION
There was a post on discoverygc saying that they'd like more dice features. 
Dice command rewritten to support 1d20[+-] operations.

Image attached for ingame visual

![diceroll](https://user-images.githubusercontent.com/9699789/37691519-f358d26a-2c88-11e8-9476-87de967be34b.png)

The line explaining what each individual dice roll was is not displayed if there are more than 9 dice being rolled. Keep the screen clean from too much clutter. (and message limits somewhere down the line)
