### PR TITLE
Remove the ability for ships to get stuck when blind jumping

### DIFF
--- a/Binaries/bin-conf/flhook_plugins/jump.cfg
+++ b/Binaries/bin-conf/flhook_plugins/jump.cfg
@@ -1,14 +1,18 @@
 [general]
-; Bastille
-death_system = iw09
-; Connecticut
-death_system = Li06
-; Unknown
+; systems the jump ship is killed upon entering
 death_system = No01
 death_system = CA01
-death_system = sector01
-death_system = sector02
-death_system = sector03
+; Systems we cannot blind jump to. Done to systems users cannot escape from or carry the possibility of abuse
+banned_system = sector01
+banned_system = sector02
+banned_system = sector03
+banned_system = iw09; stop people from trying to break ships out of Bastille using a matrix and jdiv
+banned_system = li06
+banned_system = st03c
+; Atmosphere Systems
+banned_system = EV02
+banned_system = EV03
+banned_system = BR10
 
 ;ShipRestrictions enabled or not (Can the ship jump or not)
 JumpWhiteListEnabled = 1

--- a/Plugins/Public/playercntl_plugin/HyperJump.cpp
+++ b/Plugins/Public/playercntl_plugin/HyperJump.cpp
@@ -1876,8 +1876,8 @@ namespace HyperJump
 				systems.push_back(sysinfo->nickname);
 				sysinfo = Universe::GetNextSystem();
 			}
-			int x = 0;
-			while(x == 0)
+			bool x = true;
+			while(x)
 			{
 				// Pick a random system and position
 				jd.iTargetSystem = CreateID(systems[rand() % systems.size()].c_str());
@@ -1886,7 +1886,7 @@ namespace HyperJump
 					PrintUserCmdText(iClientID, L"ERR: Hyper Drive Malfunction. Recalculating Jump.");
 					continue;
 				}
-				x = 1;
+				x = false;
 			}
 			jd.vTargetPosition.x = ((rand() * 10) % 400000) - 200000.0f;
 			jd.vTargetPosition.y = ((rand() * 10) % 400000) - 200000.0f;

--- a/Plugins/Public/playercntl_plugin/HyperJump.cpp
+++ b/Plugins/Public/playercntl_plugin/HyperJump.cpp
@@ -172,7 +172,8 @@ namespace HyperJump
 
 	static string set_scEncryptKey = "secretcode";
 
-	static map<uint, bool> set_death_systems;
+	static map<uint, bool> set_death_systems; // Systems the user is killed upon entering
+	static map<uint, bool> set_banned_systems;  // Systems that cannot be random jumped to.
 
 	static wstring FormatCoords(char* ibuf)
 	{
@@ -300,6 +301,11 @@ namespace HyperJump
 						{
 							set_death_systems[CreateID(ini.get_value_string(0))] = true;
 						}
+						else if (ini.is_value("banned_system"))
+						{
+							set_banned_systems[CreateID(ini.get_value_string(0))] = true;
+						}
+
 						else if (ini.is_value("JumpWhiteListEnabled"))
 						{
 						JumpWhiteListEnabled = ini.get_value_int(0);
@@ -1870,12 +1876,21 @@ namespace HyperJump
 				systems.push_back(sysinfo->nickname);
 				sysinfo = Universe::GetNextSystem();
 			}
-
-			// Pick a random system and position
-			jd.iTargetSystem = CreateID(systems[rand() % systems.size()].c_str());
-			jd.vTargetPosition.x = ((rand()*10) % 400000) - 200000.0f;
-			jd.vTargetPosition.y = ((rand()*10) % 400000) - 200000.0f;
-			jd.vTargetPosition.z = ((rand()*10) % 400000) - 200000.0f;
+			int x = 0;
+			while(x == 0)
+			{
+				// Pick a random system and position
+				jd.iTargetSystem = CreateID(systems[rand() % systems.size()].c_str());
+				if (set_banned_systems.find(jd.iTargetSystem) != set_banned_systems.end())
+				{
+					PrintUserCmdText(iClientID, L"ERR: Hyper Drive Malfunction. Recalculating Jump.");
+					continue;
+				}
+				x = 1;
+			}
+			jd.vTargetPosition.x = ((rand() * 10) % 400000) - 200000.0f;
+			jd.vTargetPosition.y = ((rand() * 10) % 400000) - 200000.0f;
+			jd.vTargetPosition.z = ((rand() * 10) % 400000) - 200000.0f;
 		}
 
 		// Start the jump timer.

--- a/Plugins/Public/playercntl_plugin/HyperJump.cpp
+++ b/Plugins/Public/playercntl_plugin/HyperJump.cpp
@@ -1876,8 +1876,8 @@ namespace HyperJump
 				systems.push_back(sysinfo->nickname);
 				sysinfo = Universe::GetNextSystem();
 			}
-			bool x = true;
-			while(x)
+			bool isBannedSystem = true;
+			while(isBannedSystem)
 			{
 				// Pick a random system and position
 				jd.iTargetSystem = CreateID(systems[rand() % systems.size()].c_str());
@@ -1886,7 +1886,7 @@ namespace HyperJump
 					PrintUserCmdText(iClientID, L"ERR: Hyper Drive Malfunction. Recalculating Jump.");
 					continue;
 				}
-				x = false;
+				isBannedSystem = false;
 			}
 			jd.vTargetPosition.x = ((rand() * 10) % 400000) - 200000.0f;
 			jd.vTargetPosition.y = ((rand() * 10) % 400000) - 200000.0f;


### PR DESCRIPTION
Created a new form of jump denial. death_system will kill the jumpship, but leave any ships brought. banned_system will cause the device to pick a different system instead. This keeps the exploration element of jumpdrives, while removing the ability for ships to jump into systems that they cannot escape from / ooRP systems.