### PR TITLE
base_plugin: Add damage_tick_time config value for wear and tear tickrate

### DIFF
--- a/Plugins/Public/base_plugin/CoreModule.cpp
+++ b/Plugins/Public/base_plugin/CoreModule.cpp
@@ -472,7 +472,7 @@ bool CoreModule::Timer(uint time)
 
 			pub::SpaceObj::GetHealth(space_obj, base->base_health, base->max_base_health);
 
-			if (!dont_rust)
+			if (!dont_rust && ((time%set_damage_tick_time) != 0))
 			{
 				// Reduce hitpoints to reflect wear and tear. This will eventually
 				// destroy the base unless it is able to repair itself.

--- a/Plugins/Public/base_plugin/CoreModule.cpp
+++ b/Plugins/Public/base_plugin/CoreModule.cpp
@@ -472,7 +472,7 @@ bool CoreModule::Timer(uint time)
 
 			pub::SpaceObj::GetHealth(space_obj, base->base_health, base->max_base_health);
 
-			if (!dont_rust && ((time%set_damage_tick_time) != 0))
+			if (!dont_rust && ((time%set_damage_tick_time) == 0))
 			{
 				// Reduce hitpoints to reflect wear and tear. This will eventually
 				// destroy the base unless it is able to repair itself.

--- a/Plugins/Public/base_plugin/CoreModule.cpp
+++ b/Plugins/Public/base_plugin/CoreModule.cpp
@@ -462,7 +462,7 @@ bool CoreModule::Timer(uint time)
 		return false;
 	}
 
-	if ((time%set_damage_tick_time) != 0)
+	if ((time%set_tick_time) != 0)
 		return false;
 
 	if (space_obj)

--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -74,6 +74,9 @@ string set_status_path_json;
 /// Damage to the base every tick
 uint set_damage_per_tick = 600;
 
+// The seconds per damage tick
+uint set_damage_tick_time = 16;
+
 // The seconds per tick
 uint set_tick_time = 16;
 
@@ -382,6 +385,10 @@ void LoadSettingsActual()
 					else if (ini.is_value("damage_per_tick"))
 					{
 						set_damage_per_tick = ini.get_value_int(0);
+					}
+					else if (ini.is_value("damage_tick_time"))
+					{
+						set_damage_tick_time = ini.get_value_int(0);
 					}
 					else if (ini.is_value("tick_time"))
 					{

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -564,6 +564,9 @@ extern uint set_damage_per_10sec;
 /// Damage to the base every tick
 extern uint set_damage_per_tick;
 
+/// The seconds per damage tick
+extern uint set_damage_tick_time;
+
 /// The seconds per tick
 extern uint set_tick_time;
 


### PR DESCRIPTION
This change to the base plugin decouples the wear and tear tickrate from the general base tickrate. This will allow server admins to increase the time between wear and tear damage while not affecting the general tickrate of the base plugin.

This change adds the "damage_tick_time" configuration option to the base plugin's configuration file. It functions in the same manner as the "tick_time" configuration option, but for the wear and tear tickrate instead of the general tickrate.